### PR TITLE
fix: accept if cargo is blocking while waiting for a lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-results"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Connor Wood <connorwood71@gmail.com"]
 keywords = ["test", "cargo"]
 license = "MIT"

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,64 +1,45 @@
 use utility_parsers::rest_of_line;
 
 named!(
+    blocking<()>,
+    do_parse!(ws!(tag!("Blocking")) >> rest_of_line >> ())
+);
+
+named!(
     compiling<()>,
-    do_parse!(
-      ws!(tag!("Compiling")) >>
-      rest_of_line >>
-      ()
-    )
+    do_parse!(ws!(tag!("Compiling")) >> rest_of_line >> ())
 );
 
 named!(
     downloading<()>,
-    do_parse!(
-      ws!(tag!("Downloading")) >>
-      rest_of_line >>
-      ()
-    )
+    do_parse!(ws!(tag!("Downloading")) >> rest_of_line >> ())
 );
 
 named!(
     downloaded<()>,
-    do_parse!(
-      ws!(tag!("Downloaded")) >>
-      rest_of_line >>
-      ()
-    )
+    do_parse!(ws!(tag!("Downloaded")) >> rest_of_line >> ())
 );
 
 named!(
-  installing<()>,
-    do_parse!(
-      ws!(tag!("Installing")) >>
-      rest_of_line >>
-      ()
-    )
+    installing<()>,
+    do_parse!(ws!(tag!("Installing")) >> rest_of_line >> ())
 );
 
 named!(
     updating<()>,
-      do_parse!(
-        ws!(tag!("Updating")) >>
-        rest_of_line >>
-        ()
-      )
+    do_parse!(ws!(tag!("Updating")) >> rest_of_line >> ())
 );
 
 named!(
     finished<()>,
-    do_parse!(
-        ws!(tag!("Finished")) >>
-        rest_of_line >>
-        ()
-    )
+    do_parse!(ws!(tag!("Finished")) >> rest_of_line >> ())
 );
 
 named!(
     pub cargo_header<()>,
     do_parse!(
         many0!(
-            alt!(updating | downloading | downloaded | installing | compiling | finished)
+            alt!(blocking | updating | downloading | downloaded | installing | compiling | finished)
         ) >>
         ()
     )
@@ -68,14 +49,12 @@ named!(
 mod tests {
     use nom::IResult;
     use std::fmt::Debug;
-    
-    use super::{updating, downloading, downloaded, compiling, installing, finished, cargo_header};
 
+    use super::{
+        blocking, cargo_header, compiling, downloaded, downloading, finished, installing, updating,
+    };
     fn assert_done<R: PartialEq + Debug>(l: IResult<&[u8], R>, r: R) {
-        assert_eq!(
-            l,
-            IResult::Done(&b""[..], r)
-        )
+        assert_eq!(l, IResult::Done(&b""[..], r))
     }
 
     #[test]
@@ -86,14 +65,13 @@ mod tests {
         assert_done(updating(output), ());
     }
 
-        #[test]
+    #[test]
     fn it_should_parse_a_downloaded_line() {
         let output = &b" Downloaded nvpair-sys v0.1.0
 "[..];
 
         assert_done(downloaded(output), ())
     }
-    
     #[test]
     fn it_should_parse_a_downloading_line() {
         let output = &b" Downloading nvpair-sys v0.1.0
@@ -122,8 +100,15 @@ mod tests {
     fn it_should_parse_a_finished_line() {
         let output = &b"    Finished debug [unoptimized + debuginfo] target(s) in 0.0 secs
 "[..];
-        
         assert_done(finished(output), ());
+    }
+
+    #[test]
+    fn it_should_parse_a_blocking_line() {
+        let output = &b"    Blocking waiting for file lock on package cache
+"[..];
+
+        assert_done(blocking(output), ());
     }
 
     #[test]

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -526,3 +526,201 @@ To learn more, run the command again with --verbose.
         ],
     );
 }
+
+#[test]
+fn test_success_on_windows_rust_1_39() {
+    let output = b"    Blocking waiting for file lock on package cache
+    Blocking waiting for file lock on package cache
+    Blocking waiting for file lock on package cache
+   Compiling cfg-if v0.1.10
+   Compiling autocfg v0.1.7
+   Compiling winapi v0.3.8
+   Compiling lazy_static v1.4.0
+   Compiling semver-parser v0.7.0
+   Compiling libc v0.2.65
+   Compiling byteorder v1.3.2
+   Compiling maybe-uninit v2.0.0
+   Compiling futures v0.1.29
+   Compiling log v0.4.8
+   Compiling proc-macro2 v1.0.6                                                                                                          
+   Compiling iovec v0.1.4                                                                                                                
+   Compiling unicode-xid v0.2.0                                                                                                          
+   Compiling syn v1.0.8                                                                                                                  
+   Compiling winapi-build v0.1.1                                                                                                         
+   Compiling scopeguard v1.0.0                                                                                                           
+   Compiling cc v1.0.47                                                                                                                  
+   Compiling fnv v1.0.6                                                                                                                  
+   Compiling winapi v0.2.8                                                                                                               
+   Compiling slab v0.4.2                                                                                                                 
+   Compiling proc-macro2 v0.4.30                                                                                                         
+   Compiling unicode-xid v0.1.0                                                                                                          
+   Compiling rand_core v0.4.2                                                                                                            
+   Compiling memchr v2.2.1                                                                                                               
+   Compiling syn v0.15.44                                                                                                                
+   Compiling matches v0.1.8                                                                                                              
+   Compiling getrandom v0.1.13                                                                                                           
+   Compiling regex-syntax v0.6.12                                                                                                        
+   Compiling itoa v0.4.4                                                                                                                 
+   Compiling ppv-lite86 v0.2.6                                                                                                           
+   Compiling failure_derive v0.1.6                                                                                                       
+   Compiling serde v1.0.102                                                                                                              
+   Compiling rustc-demangle v0.1.16                                                                                                      
+   Compiling ipconfig v0.2.1                                                                                                             
+   Compiling ryu v1.0.2                                                                                                                  
+   Compiling percent-encoding v1.0.1                                                                                                     
+   Compiling copyless v0.1.4
+   Compiling quick-error v1.2.2                                                                                                          
+   Compiling linked-hash-map v0.5.2                                                                                                      
+   Compiling widestring v0.4.0                                                                                                           
+   Compiling crc32fast v1.2.0                                                                                                            
+   Compiling either v1.5.3                                                                                                               
+   Compiling percent-encoding v2.1.0                                                                                                     
+   Compiling slog v2.5.2                                                                                                                 
+   Compiling encoding_rs v0.8.20                                                                                                         
+   Compiling httparse v1.3.4                                                                                                             
+   Compiling bitflags v1.2.1                                                                                                             
+   Compiling dtoa v0.4.4                                                                                                                 
+   Compiling language-tags v0.2.2                                                                                                        
+   Compiling sha1 v0.6.0                                                                                                                 
+   Compiling mime v0.3.14                                                                                                                
+   Compiling protobuf v2.8.1                                                                                                             
+   Compiling arc-swap v0.4.3                                                                                                             
+   Compiling prometheus v0.7.0                                                                                                           
+   Compiling hashbrown v0.5.0                                                                                                            
+   Compiling spin v0.5.2                                                                                                                 
+   Compiling crossbeam-utils v0.6.6                                                                                                      
+   Compiling thread_local v0.3.6                                                                                                         
+   Compiling semver v0.9.0                                                                                                               
+   Compiling rand_pcg v0.1.2                                                                                                             
+   Compiling rand_chacha v0.1.1                                                                                                          
+   Compiling crossbeam-utils v0.7.0                                                                                                      
+   Compiling rand v0.6.5                                                                                                                 
+   Compiling num-traits v0.2.8                                                                                                           
+   Compiling num-integer v0.1.41                                                                                                         
+   Compiling indexmap v1.3.0                                                                                                             
+   Compiling hashbrown v0.6.3                                                                                                            
+   Compiling crossbeam-epoch v0.8.0                                                                                                      
+   Compiling lock_api v0.3.1                                                                                                             
+   Compiling ws2_32-sys v0.2.1                                                                                                           
+   Compiling kernel32-sys v0.2.2                                                                                                         
+   Compiling tokio-sync v0.1.7                                                                                                           
+   Compiling actix-service v0.4.2                                                                                                        
+   Compiling rand_core v0.3.1                                                                                                            
+   Compiling unicode-bidi v0.3.4                                                                                                         
+   Compiling backtrace-sys v0.1.32                                                                                                       
+   Compiling miniz-sys v0.1.12                                                                                                           
+   Compiling brotli-sys v0.3.2                                                                                                           
+   Compiling c2-chacha v0.2.3                                                                                                            
+   Compiling lru-cache v0.1.2                                                                                                            
+   Compiling tokio-executor v0.1.8                                                                                                       
+   Compiling rustc_version v0.2.3                                                                                                        
+   Compiling rand_isaac v0.1.1                                                                                                           
+   Compiling rand_hc v0.1.0                                                                                                              
+   Compiling rand_xorshift v0.1.1                                                                                                        
+   Compiling tokio-timer v0.2.11                                                                                                         
+   Compiling tokio-current-thread v0.1.6                                                                                                 
+   Compiling parking_lot_core v0.6.2                                                                                                     
+   Compiling parking_lot v0.9.0                                                                                                          
+   Compiling memoffset v0.5.3                                                                                                            
+   Compiling num_cpus v1.11.0                                                                                                            
+   Compiling smallvec v0.6.13                                                                                                            
+   Compiling bytes v0.4.12                                                                                                               
+   Compiling base64 v0.10.1                                                                                                              
+   Compiling quote v1.0.2                                                                                                                
+   Compiling quote v0.6.13                                                                                                               
+   Compiling aho-corasick v0.7.6                                                                                                         
+   Compiling rand_core v0.5.1                                                                                                            
+   Compiling net2 v0.2.33                                                                                                                
+   Compiling rand_jitter v0.1.4                                                                                                          
+   Compiling socket2 v0.3.11                                                                                                             
+   Compiling rand_os v0.1.3                                                                                                              
+   Compiling winutil v0.1.1                                                                                                              
+   Compiling winreg v0.6.2                                                                                                               
+   Compiling time v0.1.42                                                                                                                
+   Compiling slog-scope v4.3.0                                                                                                           
+   Compiling threadpool v1.7.1                                                                                                           
+   Compiling crossbeam-queue v0.2.0                                                                                                      
+   Compiling crossbeam-channel v0.4.0                                                                                                    
+   Compiling unicode-normalization v0.1.9                                                                                                
+   Compiling tokio-io v0.1.12                                                                                                            
+   Compiling http v0.1.19                                                                                                                
+   Compiling string v0.2.1                                                                                                               
+   Compiling backtrace v0.3.40                                                                                                           
+   Compiling rand_chacha v0.2.1                                                                                                          
+   Compiling miow v0.2.1                                                                                                                 
+   Compiling regex v1.3.1                                                                                                                
+   Compiling hostname v0.1.5                                                                                                             
+   Compiling flate2 v1.0.12                                                                                                              
+   Compiling brotli2 v0.3.2                                                                                                              
+   Compiling idna v0.1.5                                                                                                                 
+   Compiling idna v0.2.0                                                                                                                 
+   Compiling tokio-codec v0.1.1                                                                                                          
+   Compiling chrono v0.4.9                                                                                                               
+   Compiling h2 v0.1.26                                                                                                                  
+   Compiling rand v0.7.2                                                                                                                 
+   Compiling mio v0.6.19                                                                                                                 
+   Compiling enum-as-inner v0.2.1                                                                                                        
+   Compiling resolv-conf v0.6.2                                                                                                          
+   Compiling synstructure v0.12.2                                                                                                        
+   Compiling url v1.7.2                                                                                                                  
+   Compiling url v2.1.0                                                                                                                  
+   Compiling actix-codec v0.1.2                                                                                                          
+   Compiling derive_more v0.15.0                                                                                                         
+   Compiling serde_derive v1.0.102                                                                                                       
+   Compiling proc-macro-hack v0.5.11                                                                                                     
+   Compiling actix-web-codegen v0.1.3                                                                                                    
+   Compiling crossbeam-deque v0.7.2                                                                                                      
+   Compiling tokio-reactor v0.1.10                                                                                                       
+   Compiling actix-utils v0.4.7                                                                                                          
+   Compiling const-random-macro v0.1.6                                                                                                   
+   Compiling crossbeam v0.7.3                                                                                                            
+   Compiling tokio-tcp v0.1.3                                                                                                            
+   Compiling tokio-udp v0.1.5                                                                                                            
+   Compiling tokio-signal v0.2.7                                                                                                         
+   Compiling const-random v0.1.6                                                                                                         
+   Compiling slog-stdlog v4.0.0                                                                                                          
+   Compiling actix-server-config v0.1.2                                                                                                  
+   Compiling failure v0.1.6                                                                                                              
+   Compiling actix-threadpool v0.1.2                                                                                                     
+   Compiling ahash v0.2.17                                                                                                               
+   Compiling trust-dns-proto v0.7.4                                                                                                      
+   Compiling actix-rt v0.2.5                                                                                                             
+   Compiling actix-server v0.6.1                                                                                                         
+   Compiling actix-testing v0.1.0                                                                                                        
+   Compiling trust-dns-resolver v0.11.1                                                                                                  
+   Compiling actix-connect v0.2.5                                                                                                        
+   Compiling serde_json v1.0.41                                                                                                          
+   Compiling serde_urlencoded v0.6.1
+   Compiling actix-router v0.1.5
+   Compiling actix-http v0.2.11                                                                                                          
+   Compiling slog-json v2.3.0
+   Compiling awc v0.2.8                                                                                                                  
+   Compiling actix-web v1.0.8                                                                                                            
+   Compiling app v0.1.0 (C:\\Temp\\Rust)                                               
+    Finished dev [unoptimized + debuginfo] target(s) in 6m 22s                                                                           
+     Running target\\debug\\deps\\app-622eefdc86aa5319.exe
+
+running 1 test
+test router::handlers::tests::test_success ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+";
+
+    assert_done(
+        cargo_test_result_parser(output),
+        vec![Suite {
+            name: "target\\debug\\deps\\app-622eefdc86aa5319.exe".to_string(),
+            state: "pass".to_string(),
+            passed: 1,
+            failed: 0,
+            ignored: 0,
+            measured: 0,
+            total: 1,
+            tests: vec![Test {
+                name: "router::handlers::tests::test_success".to_string(),
+                status: "pass".to_string(),
+                error: None,
+            }],
+        }],
+    );
+}


### PR DESCRIPTION
Experiencing the parser failing since cargo 1.39.0 - seems to boil down to cargo waiting for a file lock at the beginning that is not expected by the parser. This commit seems to fix the issue - could you plz merge and publish to crate.io? Thanks in advance.